### PR TITLE
Prohibit past activation slots

### DIFF
--- a/src/KeyperSetManager.sol
+++ b/src/KeyperSetManager.sol
@@ -13,7 +13,7 @@ error AlreadyDeactivated();
 
 contract KeyperSetManager is AccessControl, Pausable {
     struct KeyperSetData {
-        uint64 activationSlot;
+        uint64 activationBlock;
         address contractAddress;
     }
 
@@ -21,21 +21,21 @@ contract KeyperSetManager is AccessControl, Pausable {
 
     KeyperSetData[] private keyperSets;
 
-    event KeyperSetAdded(uint64 activationSlot, address keyperSetContract);
+    event KeyperSetAdded(uint64 activationBlock, address keyperSetContract);
 
     constructor() {
         _grantRole(DEFAULT_ADMIN_ROLE, msg.sender);
     }
 
     function addKeyperSet(
-        uint64 activationSlot,
+        uint64 activationBlock,
         address keyperSetContract
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         if (
             keyperSets.length > 0 &&
-            activationSlot <
+            activationBlock <
             Math.max(
-                keyperSets[keyperSets.length - 1].activationSlot,
+                keyperSets[keyperSets.length - 1].activationBlock,
                 block.number + 1
             )
         ) {
@@ -44,29 +44,29 @@ contract KeyperSetManager is AccessControl, Pausable {
         if (!KeyperSet(keyperSetContract).isFinalized()) {
             revert KeyperSetNotFinalized();
         }
-        keyperSets.push(KeyperSetData(activationSlot, keyperSetContract));
-        emit KeyperSetAdded(activationSlot, keyperSetContract);
+        keyperSets.push(KeyperSetData(activationBlock, keyperSetContract));
+        emit KeyperSetAdded(activationBlock, keyperSetContract);
     }
 
     function getNumKeyperSets() external view returns (uint64) {
         return uint64(keyperSets.length);
     }
 
-    function getKeyperSetIndexBySlot(
-        uint64 slot
+    function getKeyperSetIndexByBlock(
+        uint64 blockNumber
     ) external view returns (uint64) {
         for (uint256 i = keyperSets.length; i > 0; i--) {
-            if (keyperSets[i - 1].activationSlot <= slot) {
+            if (keyperSets[i - 1].activationBlock <= blockNumber) {
                 return uint64(i - 1);
             }
         }
         revert NoActiveKeyperSet();
     }
 
-    function getKeyperSetActivationSlot(
+    function getKeyperSetActivationBlock(
         uint64 index
     ) external view returns (uint64) {
-        return keyperSets[index].activationSlot;
+        return keyperSets[index].activationBlock;
     }
 
     function getKeyperSetAddress(uint64 index) external view returns (address) {

--- a/test/KeyperSetManager.t.sol
+++ b/test/KeyperSetManager.t.sol
@@ -57,14 +57,14 @@ contract KeyperSetManagerTest is Test {
     function testAddKeyperSetRequiresFutureActivationBlock() public {
         keyperSetManager.addKeyperSet(10, address(members0));
         vm.roll(15);
-        uint64 currentEon = keyperSetManager.getKeyperSetIndexBySlot(15);
-        assertEq(10, keyperSetManager.getKeyperSetActivationSlot(currentEon));
+        uint64 currentEon = keyperSetManager.getKeyperSetIndexByBlock(15);
+        assertEq(10, keyperSetManager.getKeyperSetActivationBlock(currentEon));
         vm.expectRevert(AlreadyHaveKeyperSet.selector);
         keyperSetManager.addKeyperSet(15, address(members1));
         keyperSetManager.addKeyperSet(16, address(members1));
     }
 
-    event KeyperSetAdded(uint64 activationSlot, address keyperSetContract);
+    event KeyperSetAdded(uint64 activationBlock, address keyperSetContract);
 
     function testAddKeyperSetEmits() public {
         vm.expectEmit(address(keyperSetManager));
@@ -72,33 +72,33 @@ contract KeyperSetManagerTest is Test {
         keyperSetManager.addKeyperSet(1000, address(members0));
     }
 
-    function testGetKeyperSetIndexBySlotEmpty() public {
+    function testGetKeyperSetIndexByBlockEmpty() public {
         vm.expectRevert(NoActiveKeyperSet.selector);
-        keyperSetManager.getKeyperSetIndexBySlot(0);
+        keyperSetManager.getKeyperSetIndexByBlock(0);
     }
 
-    function testGetKeyperSetIndexBySlot() public {
+    function testGetKeyperSetIndexByBlock() public {
         keyperSetManager.addKeyperSet(1000, address(members0));
         keyperSetManager.addKeyperSet(1100, address(members1));
 
         vm.expectRevert(NoActiveKeyperSet.selector);
-        keyperSetManager.getKeyperSetIndexBySlot(0);
+        keyperSetManager.getKeyperSetIndexByBlock(0);
 
         vm.expectRevert(NoActiveKeyperSet.selector);
-        keyperSetManager.getKeyperSetIndexBySlot(999);
+        keyperSetManager.getKeyperSetIndexByBlock(999);
 
-        assertEq(keyperSetManager.getKeyperSetIndexBySlot(1000), 0);
-        assertEq(keyperSetManager.getKeyperSetIndexBySlot(1099), 0);
+        assertEq(keyperSetManager.getKeyperSetIndexByBlock(1000), 0);
+        assertEq(keyperSetManager.getKeyperSetIndexByBlock(1099), 0);
 
-        assertEq(keyperSetManager.getKeyperSetIndexBySlot(1100), 1);
-        assertEq(keyperSetManager.getKeyperSetIndexBySlot(1250), 1);
+        assertEq(keyperSetManager.getKeyperSetIndexByBlock(1100), 1);
+        assertEq(keyperSetManager.getKeyperSetIndexByBlock(1250), 1);
     }
 
-    function testGetKeyperSetActivationSlot() public {
+    function testGetKeyperSetActivationBlock() public {
         keyperSetManager.addKeyperSet(1000, address(members0));
         keyperSetManager.addKeyperSet(1100, address(members1));
-        assertEq(keyperSetManager.getKeyperSetActivationSlot(0), 1000);
-        assertEq(keyperSetManager.getKeyperSetActivationSlot(1), 1100);
+        assertEq(keyperSetManager.getKeyperSetActivationBlock(0), 1000);
+        assertEq(keyperSetManager.getKeyperSetActivationBlock(1), 1100);
     }
 
     function testGetKeyperSetAddress() public {


### PR DESCRIPTION
* include check that activationBlock is at least > currentBlock when adding a keyper set
* rename slot to block